### PR TITLE
Add `-fPIE` to ggcat-cpp-api `Makefile`

### DIFF
--- a/crates/capi/ggcat-cpp-api/Makefile
+++ b/crates/capi/ggcat-cpp-api/Makefile
@@ -8,7 +8,7 @@ clean:
 
 lib/libggcat_api.a: ./lib/libggcat_cpp_bindings.a
 	mkdir -p build/
-	$(CXX) -std=c++11 -O3 -Wno-unused-command-line-argument -I./include -I./src -c ./src/ggcat.cc -lggcat_cpp_bindings -lggcat_cxx_interop -o build/ggcat.o -Wall -Wextra -Werror
+	$(CXX) -std=c++11 -fPIE -O3 -Wno-unused-command-line-argument -I./include -I./src -c ./src/ggcat.cc -lggcat_cpp_bindings -lggcat_cxx_interop -o build/ggcat.o -Wall -Wextra -Werror
 	ar cr lib/libggcat_api.a build/ggcat.o
 
 ./lib/libggcat_cpp_bindings.a: ggcat-source


### PR DESCRIPTION
I encountered a linking error when trying to link the ggcat static library in [`fulgor`](https://github.com/jermp/fulgor) under g++-11.1.  I had to add this flag to the command for compiling `libggcat_api.a` to fix it.  I don't think it should disturb anything else. cc @jermp